### PR TITLE
UXODS-190 Move Fonts to Theme Model

### DIFF
--- a/src/scss/_accordion.scss
+++ b/src/scss/_accordion.scss
@@ -4,6 +4,7 @@
 .emc-accordion h4,
 .emc-accordion h5,
 .emc-accordion h6 {
+  font-family: emc-theme-font(accordion-header);
   margin: 0px;
 }
 .emc-accordion__button {
@@ -16,7 +17,7 @@
   width: 100%;
   text-align: left;
   cursor: pointer;
-  font-family: $font-face-heading-default;
+  font-family: emc-theme-font(accordion-header);
 }
 .emc-accordion__button[aria-expanded='true'] {
   background-color: #f4f4f4;

--- a/src/scss/_breadcrumb.scss
+++ b/src/scss/_breadcrumb.scss
@@ -1,6 +1,7 @@
 .emc-breadcrumb {
   padding-bottom: 1rem;
   padding-top: 1rem;
+  font-family: emc-theme-font(body);
   font-size: 1.06rem;
   line-height: 1.3;
   color: #1b1b1b;

--- a/src/scss/_button.scss
+++ b/src/scss/_button.scss
@@ -1,4 +1,5 @@
 .emc-btn {
+  font-family: emc-theme-font(body);
   font-size: 1.06rem;
   line-height: .9;
   -moz-osx-font-smoothing: grayscale;

--- a/src/scss/_cards.scss
+++ b/src/scss/_cards.scss
@@ -4,6 +4,7 @@
 }
 
 .emc-card__heading {
+  font-family: emc-theme-font(heading-default);
   font-style: normal;
   font-weight: 600;
   font-size: px-to-rem(14);
@@ -23,6 +24,7 @@
 .emc-card__footer {
   @include emc-theme-color(neutral-light);
   padding: px-to-rem(10) px-to-rem(12);
+  font-family: emc-theme-font(body);
   font-style: normal;
   font-weight: 700;
   font-size: px-to-rem(10);
@@ -33,6 +35,7 @@
 
 .emc-news-card {
   @include emc-theme-color(card);
+  font-family: emc-theme-font(header-default);
   display: flex;
   flex-direction: column;
   // this allows the card to properly take up space when put into a flex container
@@ -93,6 +96,7 @@
   margin-bottom: px-to-rem(12);
 }
 .emc-event-card__title a {
+  font-family: emc-theme-font(header-default);
   font-size: 1.25rem;
   font-weight: bold;
   text-decoration: none;

--- a/src/scss/_font.scss
+++ b/src/scss/_font.scss
@@ -1,0 +1,9 @@
+$emc-font-map: (
+        emc-lora: ('Lora', serif),
+        emc-sans: ('Public Sans', sans-serif),
+        emc-roboto: ('Roboto', sans-serif)
+);
+
+@each $key, $value in $emc-font-map {
+  .#{$key} { font-family: $value; }
+}

--- a/src/scss/_footer.scss
+++ b/src/scss/_footer.scss
@@ -3,6 +3,14 @@ footer.emc-footer {
   color: #fff;
   padding-top: 2rem;
 }
+footer.emc-footer h1,
+footer.emc-footer h2,
+footer.emc-footer h3,
+footer.emc-footer h4,
+footer.emc-footer h5,
+footer.emc-footer h6 {
+  font-family: emc-theme-font(body);
+}
 footer.emc-footer h2 {
   font-size: 1rem;
   text-transform: uppercase;

--- a/src/scss/_headings.scss
+++ b/src/scss/_headings.scss
@@ -1,7 +1,8 @@
 h1, .emc-h1 {
+  font-family: emc-theme-font(header-default);
   font-weight: 400;
   font-size: px-to-rem(53);
-  line-height: px-to-rem(72);
+  line-height: px-to-rem(64);
   margin: .4em 0;
   text-transform: none;
   margin-block-start: 0.67em;
@@ -9,6 +10,7 @@ h1, .emc-h1 {
 }
 
 h2, .emc-h2 {
+  font-family: emc-theme-font(header-default);
   font-weight: 600;
   font-size: px-to-rem(34);
   line-height: px-to-rem(48);
@@ -18,6 +20,7 @@ h2, .emc-h2 {
 }
 
 h3, .emc-h3 {
+  font-family: emc-theme-font(header-default);
   font-weight: 600;
   font-size: px-to-rem(24);
   line-height: px-to-rem(27);
@@ -27,6 +30,7 @@ h3, .emc-h3 {
 }
 
 h4, .emc-h4 {
+  font-family: emc-theme-font(header-default);
   font-weight: 700;
   font-size: px-to-rem(21);
   line-height: px-to-rem(27);
@@ -36,6 +40,7 @@ h4, .emc-h4 {
 }
 
 h5, .emc-h5 {
+  font-family: emc-theme-font(header-default);
   font-weight: 700;
   font-size: px-to-rem(16);
   line-height: px-to-rem(27);
@@ -45,6 +50,7 @@ h5, .emc-h5 {
 }
 
 h6, .emc-h6 {
+  font-family: emc-theme-font(header-default);
   font-weight: 700;
   font-size: px-to-rem(16);
   line-height: px-to-rem(27);
@@ -54,6 +60,7 @@ h6, .emc-h6 {
 }
 
 .emc-display-heading {
+  font-family: emc-theme-font(header-default);
   font-weight: 700;
   font-size: px-to-rem(53);
   line-height: 4rem;
@@ -63,6 +70,7 @@ h6, .emc-h6 {
 }
 
 .emc-block-heading {
+  font-family: emc-theme-font(header-default);
   font-weight: 700;
 }
 
@@ -76,6 +84,7 @@ h6, .emc-h6 {
 }
 
 .emc-page-title {
+  font-family: emc-theme-font(header-default);
   border-bottom: px-to-rem(3) solid emc-theme-rgb(accent);
   padding-bottom: px-to-rem(5);
   margin: 0.2em 0 0.75em;

--- a/src/scss/_modal-dialog.scss
+++ b/src/scss/_modal-dialog.scss
@@ -21,6 +21,7 @@
 
 .emc-modal-window {
   @include emc-theme-color(modal);
+  font-family: emc-theme-font(body);
   font-size: 1rem;
   padding: px-to-rem(10);
   position: absolute;

--- a/src/scss/_pager.scss
+++ b/src/scss/_pager.scss
@@ -2,6 +2,7 @@
   display: inline-block;
   padding-left: px-to-rem(0);
   margin: px-to-rem(20) px-to-rem(0);
+  font-family: emc-theme-font(body);
   font-size: 1rem;
   line-height: .9;
 }

--- a/src/scss/_tabs.scss
+++ b/src/scss/_tabs.scss
@@ -27,6 +27,7 @@ a.emc-tab-link {
   text-decoration: none;
   color: rgba(0,0,0,.87);
   height: px-to-rem(40);
+  font-family: emc-theme-font(body);
   font-style: normal;
   font-weight: 700;
   font-size: px-to-rem(14);

--- a/src/scss/_theme.scss
+++ b/src/scss/_theme.scss
@@ -12,3 +12,7 @@
 @function emc-theme-rgb($feature) {
   @return map-get(map-get($emc-color-map, map-get($emc-theme-feature-colors, $feature)), background-color);
 }
+
+@function emc-theme-font($feature) {
+  @return map-get($emc-font-map, map-get($emc-theme-feature-fonts, $feature));
+}

--- a/src/scss/_theme_font_default.scss
+++ b/src/scss/_theme_font_default.scss
@@ -1,0 +1,17 @@
+// default theme
+$emc-theme-feature-fonts: (
+
+    body: emc-roboto,
+    header-default: emc-lora,
+    footer-default: emc-roboto,
+
+    accordion-header: emc-roboto,
+    card-footer: emc-roboto,
+    event-card-title: emc-lora,
+    tab-link: emc-roboto,
+    pager: emc-roboto,
+    button: emc-roboto,
+    breadcrumb: emc-roboto,
+    modal: emc-roboto
+
+);

--- a/src/scss/_typography.scss
+++ b/src/scss/_typography.scss
@@ -1,4 +1,5 @@
 html {
+  font-family: emc-theme-font(body);
   font-size: $emc-rem;
   line-height: 1.875;
 }

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -5,12 +5,14 @@
 @import 'functions';
 @import 'breakpoints';
 @import 'color';
+@import 'font';
 @import 'theme_colors_default';
 // @import 'theme_colors_demo';
+@import 'theme_font_default';
 @import 'theme';
 @import 'typography';
-@import 'font_pairing_default';
-@import 'font_pairing_casual';
+//@import 'font_pairing_default';
+//@import 'font_pairing_casual';
 @import 'elevation';
 
 @import 'focus';


### PR DESCRIPTION
Modified the specification of the fonts to be the same as the way we specify colors. I did added font-family styles to specfic components/classes and they leverage a theme value for the font.

I did not delete the font_pairing files yet as I want to make sure you are ok with the changes first. I will delete them after you have approved of the changes in this commit.