### PR TITLE
UXODS-256 Footer - Trustees text is wrapping

### DIFF
--- a/src/icons/phosphor/copyright.svg
+++ b/src/icons/phosphor/copyright.svg
@@ -1,0 +1,5 @@
+<svg id="Raw" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <rect width="256" height="256" fill="none"/>
+  <circle cx="128" cy="128" r="96" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>
+  <path d="M160.00112,152.00142a40,40,0,1,1-.00029-48.013" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>
+</svg>

--- a/src/scss/_footer.scss
+++ b/src/scss/_footer.scss
@@ -54,6 +54,12 @@ ul.jazz-footer__list li {
   // margin-bottom: .50rem;
   line-height: px-to-rem(24);
   letter-spacing: px-to-rem(2);
+
+  display: inline-flex;
+  flex-basis: auto;
+  flex-grow: 0;
+  align-items: center;
+  gap: px-to-rem(4);
 }
 ul.jazz-footer__icon-list {
   list-style: none;
@@ -89,20 +95,20 @@ ul.jazz-footer__icon-list li {
 
 .jazz-footer__subfooter div {
   text-align: center;
+  line-height: px-to-rem(20);
+  flex-grow: 1;
 }
 
 @include apply-from-small-laptop-up {
-  .jazz-footer__subfooter div {
-    text-align: left;
+  .jazz-footer-text--center {
+    text-align: center;
   }
   .jazz-footer-text--left {
     text-align: left;
   }
-
   .jazz-footer-text--right {
     text-align: right;
   }
-
   .jazz-footer__logo {
     float: right;
   }

--- a/src/scss/_icon.scss
+++ b/src/scss/_icon.scss
@@ -30,10 +30,6 @@
   background-color: white;
 }
 
-.jazz-icon-white {
-  filter: invert(1);
-}
-
 .jazz-icon-transparent {
   filter: opacity(0);
 }

--- a/src/scss/_icons_standard.scss
+++ b/src/scss/_icons_standard.scss
@@ -18,6 +18,7 @@ $jazz-icons-standard: (
         arrow-left: '../icons/phosphor/arrow-left.svg',
         plus: '../icons/phosphor/plus.svg',
         minus: '../icons/phosphor/minus.svg',
+        copyright: '../icons/phosphor/copyright.svg',
 
         phone: '../icons/phosphor/phone.svg',
         printer: '../icons/phosphor/printer.svg',

--- a/stories/Footer.stories.mdx
+++ b/stories/Footer.stories.mdx
@@ -50,13 +50,13 @@ export const Template = (args) => html`
         <div class="jazz-footer__subfooter">
             <div class="jazz-container">
                 <div class="row">
-                    <div class="col-sm-4 col-xs-12">
+                    <div class="col-lg-2 col-md-2 col-sm-2 col-xs-12">
                         <a href="javascript:void(0)">Accessibility</a>
                     </div>
-                    <div class="col-sm-4 col-xs-12 jazz-footer-text--center">
+                    <div class="col-lg-8 col-md-8 col-sm-8 col-xs-12 jazz-footer-text--center">
                         &copy; 2020 The Trustees of Princeton University
                     </div>
-                    <div class="col-sm-4 col-xs-12">
+                    <div class="col-lg-2 col-md-2 col-sm-2 col-xs-12">
                         <a href="https://www.princeton.edu" target="_blank" class="jazz-no-icon"><img class="jazz-footer__logo" src="/icons/pu-logo-stacked-white.svg" alt="Princeton University" /></a>
                     </div>
                 </div>
@@ -71,19 +71,19 @@ export const TemplateSample1 = (args) => html`
             <div class="row">
                 <div class="col-sm-3 col-xs-12">
                     <ul class="jazz-footer__list">
-                        <li><i class="jazz-icon jazz-icon-email jazz-icon-white" aria-hidden="true"></i><a href="javascript:void(0);">  finance@princeton.edu</a></li>
+                        <li><i class="jazz-icon jazz-icon-email" aria-hidden="true"></i><a href="javascript:void(0);">  finance@princeton.edu</a></li>
                     </ul>
                 </div>
                 <div class="col-sm-3 col-xs-12">
                     <ul class="jazz-footer__list">
-                        <li><a href="javascript:void(0);"><i class="jazz-icon jazz-icon-phone jazz-icon-white" aria-hidden="true"></i>  609-258-3080</a></li>
-                        <li><a href="javascript:void(0);"><i class="jazz-icon jazz-icon-printer jazz-icon-white" aria-hidden="true"></i>  609-258-3080</a></li>
+                        <li><a href="javascript:void(0);"><i class="jazz-icon jazz-icon-phone" aria-hidden="true"></i>  609-258-3080</a></li>
+                        <li><a href="javascript:void(0);"><i class="jazz-icon jazz-icon-printer" aria-hidden="true"></i>  609-258-3080</a></li>
                     </ul>
                 </div>
                 <div class="col-sm-3 col-xs-12">
                     <ul class="jazz-footer__list">
                         <li><i class="jazz-icon jazz-icon-map-pin jazz-icon-transparent" aria-hidden="true"></i>  701 Carnegie Center</li>
-                        <li><i class="jazz-icon jazz-icon-map-pin jazz-icon-white" aria-hidden="true"></i>  Suite 435</li>
+                        <li><i class="jazz-icon jazz-icon-map-pin" aria-hidden="true"></i>  Suite 435</li>
                         <li><i class="jazz-icon jazz-icon-map-pin jazz-icon-transparent" aria-hidden="true"></i>  Princeton, NJ 08540</li>
                     </ul>
                 </div>
@@ -97,15 +97,15 @@ export const TemplateSample1 = (args) => html`
         <div class="jazz-footer__subfooter">
             <div class="jazz-container">
                 <div class="row">
-                    <div class="col-sm-4 col-xs-12">
-                        <a href="javascript:void(0)">Accessibility</a>
-                    </div>
-                    <div class="col-sm-4 col-xs-12 jazz-footer-text--center">
-                        &copy; 2020 The Trustees of Princeton University
-                    </div>
-                    <div class="col-sm-4 col-xs-12">
-                        <a href="https://www.princeton.edu" target="_blank" class="jazz-no-icon"><img class="jazz-footer__logo" src="/icons/pu-logo-stacked-white.svg" alt="Princeton University" /></a>
-                    </div>
+                   <div class="col-lg-2 col-md-2 col-sm-2 col-xs-12">
+                       <a href="javascript:void(0)">Accessibility</a>
+                   </div>
+                   <div class="col-lg-8 col-md-8 col-sm-8 col-xs-12 jazz-footer-text--center">
+                       &copy; 2020 The Trustees of Princeton University
+                   </div>
+                   <div class="col-lg-2 col-md-2 col-sm-2 col-xs-12">
+                       <a href="https://www.princeton.edu" target="_blank" class="jazz-no-icon"><img class="jazz-footer__logo" src="/icons/pu-logo-stacked-white.svg" alt="Princeton University" /></a>
+                   </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Text will still wrap but I have allotted more space to the middle trustee text than the two items on the left and right so it will wrap less. I have also specified a line height of 20px to make sure that the text looks like they belong together