### PR TITLE
add color and background colors for contrast accessilibility warning

### DIFF
--- a/src/scss/_hidden.scss
+++ b/src/scss/_hidden.scss
@@ -8,4 +8,8 @@
   clip: rect(0, 0, 0, 0) !important;
   white-space: nowrap !important;
   border: 0 !important;
+  // Visually Hidden Content
+  // Contrast Accessibility Warning
+  color: #000;
+  background-color: #fff;
 }


### PR DESCRIPTION
### ISSUE
- The "jazz-visually-hidden" content is being identified as an accessibility contrast issue in certain situations, probably because the content has no color or background specified.
### CHANGED
- Color and background-color descriptors added to the "jazz-visually-hidden" class.
### EXPECTED BEHAVIOR
- Contrast accessibility validation should pass without any warnings.
### ADDED
```scss
`src/scss/_hidden.scss`

.jazz-visually-hidden { 
     ...
     // Visually Hidden Content
     // Contrast Accessibility Warning
     color: #000;
     background-color: #fff; 
     ...
}
```