### PR TITLE
remove @function jazz-icons-path-with-color

### DIFF
--- a/src/scss/_icons_core.scss
+++ b/src/scss/_icons_core.scss
@@ -5,13 +5,11 @@ $jazz-icons-core: (
   linkedin: "../icons/phosphor/linkedin-logo.svg",
   instagram: "../icons/phosphor/instagram-logo.svg",
   youtube: "../icons/phosphor/youtube-logo.svg",
-
   close: "../icons/phosphor/x.svg",
   caret-up: "../icons/phosphor/caret-up.svg",
   caret-down: "../icons/phosphor/caret-down.svg",
   caret-left: "../icons/phosphor/caret-left.svg",
   caret-right: "../icons/phosphor/caret-right.svg",
-
   external: "../icons/phosphor/arrow-square-up-right.svg",
   search: "../icons/phosphor/magnifying-glass.svg",
   menu: "../icons/phosphor/list.svg",
@@ -27,7 +25,7 @@ $jazz-icons-core: (
   arrow-left: "../icons/phosphor/arrow-left.svg",
   arrow-right: "../icons/phosphor/arrow-right.svg",
   arrow-down: "../icons/phosphor/arrow-down.svg",
-  arrow-up: "../icons/phosphor/arrow-up.svg"
+  arrow-up: "../icons/phosphor/arrow-up.svg",
 );
 
 @each $name, $path in $jazz-icons-core {
@@ -42,9 +40,4 @@ $jazz-icons-core: (
 /// @return {string} The path of the specified icon.
 @function jazz-icons-path($name) {
   @return map-get($jazz-icons-core, $name);
-}
-
-@function jazz-icons-path-with-color($name, $color) {
-  @return map-get($jazz-icons-core, $name) +
-    "?stroke=" + $color + " line&fill=none";
 }


### PR DESCRIPTION
## CHANGES
- `@function jazz-icons-path-with-color($name, $color)` has been removed from `src/scss/_icons_core.scss`.