### PR TITLE
UXODS-278 Pager Updated Design

### DIFF
--- a/src/js/components/pager/pager.spec.tsx
+++ b/src/js/components/pager/pager.spec.tsx
@@ -39,7 +39,7 @@ it('We can check if the pager displays the page items correctly for a small page
     expect(ulEl.children[3].children[0].getAttribute('data-page')).toBe('3');
 
     expect(ulEl.children[4].children[0].getAttribute('data-page')).toBe('4');
-    expect(ulEl.children[4].children[0].getAttribute('aria-current')).toBe('page');
+    expect(ulEl.children[4].getAttribute('aria-current')).toBe('page');
 
     expect(ulEl.children[5].children[0].getAttribute('data-page')).toBe('5');
     expect(ulEl.children[6].children[0].getAttribute('data-page')).toBe('6');
@@ -65,7 +65,7 @@ it('We can check if the pager displays proper values after clicking next', () =>
     expect(pagerEl.getAttribute('data-current-page')).toBe('4');
     expect(ulEl.children.length).toBe(11);
     expect(ulEl.children[4].children[0].getAttribute('data-page')).toBe('4');
-    expect(ulEl.children[4].children[0].getAttribute('aria-current')).toBe('page');
+    expect(ulEl.children[4].getAttribute('aria-current')).toBe('page');
 
     const pagerEls = ulEl.querySelectorAll("li");
     expect(pagerEls.length).toBe(11);
@@ -87,7 +87,7 @@ it('We can check if the pager displays proper values after clicking next', () =>
     expect(ulEl.children[3].children[0].getAttribute('data-page')).toBe('4');
 
     expect(ulEl.children[4].children[0].getAttribute('data-page')).toBe('5');
-    expect(ulEl.children[4].children[0].getAttribute('aria-current')).toBe('page');
+    expect(ulEl.children[4].getAttribute('aria-current')).toBe('page');
 
     expect(ulEl.children[5].children[0].getAttribute('data-page')).toBe('6');
     expect(ulEl.children[6].children[0].getAttribute('data-page')).toBe('7');
@@ -110,7 +110,7 @@ it('We can check if the pager displays proper values after clicking previous', (
     expect(pagerEl.getAttribute('data-current-page')).toBe('4');
     expect(ulEl.children.length).toBe(11);
     expect(ulEl.children[4].children[0].getAttribute('data-page')).toBe('4');
-    expect(ulEl.children[4].children[0].getAttribute('aria-current')).toBe('page');
+    expect(ulEl.children[4].getAttribute('aria-current')).toBe('page');
 
     const pagerEls = ulEl.querySelectorAll("li");
 
@@ -127,7 +127,7 @@ it('We can check if the pager displays proper values after clicking previous', (
     expect(ulEl.children[2].children[0].getAttribute('data-page')).toBe('2');
 
     expect(ulEl.children[3].children[0].getAttribute('data-page')).toBe('3');
-    expect(ulEl.children[3].children[0].getAttribute('aria-current')).toBe('page');
+    expect(ulEl.children[3].getAttribute('aria-current')).toBe('page');
 
     expect(ulEl.children[4].children[0].getAttribute('data-page')).toBe('4');
     expect(ulEl.children[5].children[0].getAttribute('data-page')).toBe('5');
@@ -163,7 +163,7 @@ it('We can check if the pager handles the double truncation properly', () => {
     expect(ulEl.children[3].children[0].getAttribute('data-page')).toBe('6');
 
     expect(ulEl.children[4].children[0].getAttribute('data-page')).toBe('7');
-    expect(ulEl.children[4].children[0].getAttribute('aria-current')).toBe('page');
+    expect(ulEl.children[4].getAttribute('aria-current')).toBe('page');
 
     expect(ulEl.children[5].children[0].getAttribute('data-page')).toBe('8');
     expect(ulEl.children[6].children[0].getAttribute('data-page')).toBe('9');

--- a/src/js/components/pager/pager.ts
+++ b/src/js/components/pager/pager.ts
@@ -64,18 +64,21 @@ export class PagerBehavior extends Behavior {
 
     createLink(displayPageStr) {
         const link = document.createElement('a');
-        link.appendChild(document.createTextNode(displayPageStr));
+        // link.appendChild(document.createTextNode(displayPageStr));
+        link.appendChild(this.createSpan(displayPageStr, true));
         link.setAttribute("href", "javascript:setPage(" + displayPageStr + ");");
         link.setAttribute("aria-label", this.setAriaLabel(displayPageStr));
         link.setAttribute("data-page", displayPageStr);
         return link;
     }
 
-    createSpan(displayPageStr) {
+    createSpan(displayPageStr, isWithinLink = false) {
         const span = document.createElement('span');
         span.appendChild(document.createTextNode(displayPageStr));
-        span.setAttribute("aria-disabled", "true");
-        span.setAttribute("data-page", displayPageStr);
+        if (!isWithinLink) {
+            span.setAttribute("aria-disabled", "true");
+            span.setAttribute("data-page", displayPageStr);
+        }
         return span;
     }
 
@@ -143,8 +146,11 @@ export class PagerBehavior extends Behavior {
         selector: PAGER_SELECTOR
     })
     onClick(event: Event) {
-        // Click is on the anchor tag
-        const itemLink = <HTMLElement> event.target;
+        // Click is on the span tag
+        const itemSpan = <HTMLElement> event.target;
+
+        // Get the parent anchor tag
+        const itemLink = itemSpan.closest("a");
 
         // Get the parent list item
         const item = itemLink.closest("li");

--- a/src/scss/_pager.scss
+++ b/src/scss/_pager.scss
@@ -15,11 +15,13 @@
   flex-basis: auto;
   flex-grow: 0;
   align-items: center;
-  gap: px-to-rem(10);
+  gap: px-to-rem(16);
 
   padding-left: px-to-rem(0);
-  margin: px-to-rem(20) px-to-rem(0);
-  border-bottom: 0;
+  padding-right: px-to-rem(0);
+
+  margin: px-to-rem(20) px-to-rem(5);
+  outline: transparent px-to-rem($jazz-focus-size-px) solid;
 }
 
 .jazz-pager > ul > li a {
@@ -32,19 +34,23 @@
 
   padding-right: px-to-rem(5);
   padding-left: px-to-rem(5);
-  border-bottom: px-to-rem(4) solid jazz-theme(pager-item-bgcolor);
+
+  border-top: px-to-rem(4) solid transparent;
+  border-bottom: px-to-rem(4) solid transparent;
 }
 
-.jazz-pager > ul > li a:hover {
+.jazz-pager > ul > li a span {
+  border-top: px-to-rem(4) solid transparent;
+  border-bottom: px-to-rem(4) solid transparent;
+}
+
+.jazz-pager > ul > li a span:hover {
   border-bottom: px-to-rem(4) solid jazz-theme(pager-item-hover-underline-color);
 }
 
 .jazz-pager > ul > li a:focus {
   font-weight: bold;
   outline: px-to-rem($jazz-focus-size-px) solid jazz-theme(focus-color);
-
-  // fixing issue where left outline is missing
-  margin-left: px-to-rem(2);
 }
 
 .jazz-pager > ul > li a[aria-disabled=true],
@@ -61,17 +67,21 @@
 .jazz-pager > ul > li[aria-current=page] a:focus,
 .jazz-pager > ul > li[aria-current=page] a:hover {
   cursor: not-allowed;
+  font-weight: bold;
   color: jazz-theme(pager-item-current-color);
 }
 
-.jazz-pager > ul > li:first-child a,
-.jazz-pager > ul > li:last-child  a{
-  padding-left: 0;
-  padding-right: 0;
+.jazz-pager > ul > li[aria-current=page] a span {
+  border-bottom: px-to-rem(4) solid jazz-theme(pager-item-current-underline-color);
 }
 
 .jazz-pager > ul > li:not(:first-child):not(:last-child) > a {
   min-width: px-to-rem(25);
+}
+
+.jazz-pager > ul > li:not(:first-child):not(:last-child) > a span {
+  padding-right: 5px;
+  padding-left: 5px;
 }
 
 @include apply-to-phone-only {

--- a/src/scss/_pager.scss
+++ b/src/scss/_pager.scss
@@ -21,7 +21,6 @@
   padding-right: px-to-rem(0);
 
   margin: px-to-rem(20) px-to-rem(5);
-  outline: transparent px-to-rem($jazz-focus-size-px) solid;
 }
 
 .jazz-pager > ul > li a {
@@ -46,11 +45,6 @@
 
 .jazz-pager > ul > li a span:hover {
   border-bottom: px-to-rem(4) solid jazz-theme(pager-item-hover-underline-color);
-}
-
-.jazz-pager > ul > li a:focus {
-  font-weight: bold;
-  outline: px-to-rem($jazz-focus-size-px) solid jazz-theme(focus-color);
 }
 
 .jazz-pager > ul > li a[aria-disabled=true],

--- a/src/scss/_theme_default.scss
+++ b/src/scss/_theme_default.scss
@@ -224,9 +224,10 @@ $jazz-theme-feature: (
         pager-item-font: jazz-font(jazz-public-sans),
         pager-item-bgcolor: jazz-color(jazz-white),
         pager-item-color: jazz-color(jazz-gray-60),
-        pager-item-hover-underline-color: jazz-color(jazz-princeton-orange),
+        pager-item-hover-underline-color: jazz-color(jazz-gray-60),
         pager-item-disabled-color: jazz-color(jazz-gray-40),
-        pager-item-current-color: jazz-color(jazz-princeton-orange),
+        pager-item-current-color: jazz-color(jazz-gray),
+        pager-item-current-underline-color: jazz-color(jazz-princeton-orange),
 
         // pill
         pill-bgcolor: jazz-color(jazz-gray-20),

--- a/src/scss/_theme_serif.scss
+++ b/src/scss/_theme_serif.scss
@@ -226,9 +226,11 @@ $jazz-theme-feature: (
         pager-item-color: jazz-color(jazz-gray-60),
         pager-item-hover-underline-color: jazz-color(jazz-princeton-orange),
         pager-item-disabled-color: jazz-color(jazz-gray-40),
-        pager-item-current-color: jazz-color(jazz-princeton-orange),
+        pager-item-current-color: jazz-color(jazz-gray),
+        pager-item-current-underline-color: jazz-color(jazz-princeton-orange),
 
-        // pill
+
+  // pill
         pill-bgcolor: jazz-color(jazz-gray-20),
         pill-color: jazz-color(jazz-black),
 

--- a/stories/Pager.stories.mdx
+++ b/stories/Pager.stories.mdx
@@ -7,22 +7,22 @@ export const DefaultPagerTemplate = (args) => html`
 <nav class="jazz-pager" role="navigation" aria-label="Pagination Navigation, Current Page 2">
   <ul>
        <li>
-          <a aria-label="Go to Previous Page" href="javascript:void(0)"><i class="jazz-icon jazz-icon-caret-left"></i>Previous</a>
+          <a aria-label="Go to Previous Page" href="javascript:void(0)"><i class="jazz-icon jazz-icon-caret-left"></i><span>Previous</span></a>
        </li>
        <li>
-          <a aria-label="Go to page 1" href="javascript:void(0)">1</a>
+          <a aria-label="Go to page 1" href="javascript:void(0)"><span>1</span></a>
        </li>
        <li aria-current="page">
-          <a aria-label="Go to page 2" href="javascript:void(0)">2</a>
+          <a aria-label="Go to page 2" href="javascript:void(0)"><span>2</span></a>
       </li>
       <li>
-          <a aria-label="Go to page 3" href="javascript:void(0)">3</a>
+          <a aria-label="Go to page 3" href="javascript:void(0)"><span>3</span></a>
       </li>
       <li>
-          <a aria-label="Go to page 4" href="javascript:void(0)">4</a>
+          <a aria-label="Go to page 4" href="javascript:void(0)"><span>4</span></a>
       </li>
       <li>
-          <a aria-label="Go to Next Page" href="javascript:void(0)">Next<i class="jazz-icon jazz-icon-caret-right"></i></a>
+          <a aria-label="Go to Next Page" href="javascript:void(0)"><span>Next</span><i class="jazz-icon jazz-icon-caret-right"></i></a>
       </li>
    </ul>
 </nav>
@@ -57,22 +57,22 @@ export const ActivePagerTemplate = (args) => html`
 <nav class="jazz-pager" role="navigation" aria-label="Pagination Navigation, Current Page 3">
   <ul>
        <li>
-          <a aria-label="Go to Previous Page" href="javascript:void(0)"><i class="jazz-icon jazz-icon-caret-left"></i>Previous</a>
+          <a aria-label="Go to Previous Page" href="javascript:void(0)"><i class="jazz-icon jazz-icon-caret-left"></i><span>Previous</span></a>
        </li>
        <li aria-current="page">
-          <a aria-label="Go to page 1" href="javascript:void(0)">1</a>
+          <a aria-label="Go to page 1" href="javascript:void(0)"><span>1</span></a>
        </li>
        <li>
-          <a aria-label="Go to page 2" href="javascript:void(0)">2</a>
+          <a aria-label="Go to page 2" href="javascript:void(0)"><span>2</span></a>
        </li>
        <li>
-          <a aria-label="Go to page 3" href="javascript:void(0)">3</a>
+          <a aria-label="Go to page 3" href="javascript:void(0)"><span>3</span></a>
        </li>
         <li>
-          <a aria-label="Go to page 4" href="javascript:void(0)">4</a>
+          <a aria-label="Go to page 4" href="javascript:void(0)"><span>4</span></a>
        </li>
        <li>
-          <a aria-label="Go to Next Page" href="javascript:void(0)">Next<i class="jazz-icon jazz-icon-caret-right"></i></a>
+          <a aria-label="Go to Next Page" href="javascript:void(0)"><span>Next</span><i class="jazz-icon jazz-icon-caret-right"></i></a>
        </li>
    </ul>
 </nav>
@@ -82,25 +82,25 @@ export const TruncatePagerTemplate = (args) => html`
 <nav class="jazz-pager" role="navigation" aria-label="Pagination Navigation, Current Page 2">
   <ul>
        <li>
-          <a aria-label="Go to Previous Page" href="javascript:void(0)"><i class="jazz-icon jazz-icon-caret-left"></i>Previous</a>
+          <a aria-label="Go to Previous Page" href="javascript:void(0)"><i class="jazz-icon jazz-icon-caret-left"></i><span>Previous</span></a>
        </li>
        <li>
-          <a aria-label="Go to page 1" href="javascript:void(0)">1</a>
+          <a aria-label="Go to page 1" href="javascript:void(0)"><span>1</span></a>
        </li>
        <li aria-current="page">
-          <a aria-label="Go to page 2" href="javascript:void(0)">2</a>
+          <a aria-label="Go to page 2" href="javascript:void(0)"><span>2</span></a>
       </li>
       <li>
-          <a aria-label="Go to page 3" href="javascript:void(0)">3</a>
+          <a aria-label="Go to page 3" href="javascript:void(0)"><span>3</span></a>
       </li>
       <li>
           <span aria-disabled="true">…</span>
       </li>
       <li>
-        <a aria-label="Go to page 10" href="javascript:void(0)">10</a>
+        <a aria-label="Go to page 10" href="javascript:void(0)"><span>10</span></a>
       </li>
       <li>
-          <a aria-label="Go to Next Page" href="javascript:void(0)">Next<i class="jazz-icon jazz-icon-caret-right"></i></a>
+          <a aria-label="Go to Next Page" href="javascript:void(0)"><span>Next</span><i class="jazz-icon jazz-icon-caret-right"></i></a>
       </li>
    </ul>
 </nav>


### PR DESCRIPTION
Changes covered by this pull request:

Design Fixes:
- The hover is now a dark gray underline.
- There is a lot more space between the arrow and Prev/Next. That seems problematic for defining the click/hover target. Hover is not shown in that area so we can request that.
- Focus state is not represented.
- The current selection is now black with an orange underline (as opposed to orange text).

Issues that were resolved in this pull request:

- The Prev/Next underlines extend beyond the icon content. This is probably because it is extending to the end of the icon canvas…but that makes itlook less clean. Maybe we should push for consistency with other places where we are not underlining the icon. You can still have the icon triggerthe hover of the text as though they are linked.
- The focus indicator is causing the content to shift. The content should not move as focus moves through the pager.
- The focus indicator extends further below the text than it does above the text. This is usually because the border, margin, or padding is different onthe top than it is on the bottom.