### PR TITLE
Uxods 352  accordion smooth expand collapse behavior

### DIFF
--- a/src/scss/_accordion.scss
+++ b/src/scss/_accordion.scss
@@ -99,6 +99,36 @@
   transform: translateY(-25%);
   transition: .15s ease-in-out;
 }
+
+/**
+DEFAULT BROWSER STYLE (USER AGENT STYLESHEET) MANUAL OVERRIDE
+
+These styles correct the default styles applied by the browser for collapsed accordion contents.
+ */
+.jazz-accordion__content p:first-child ,
+.jazz-accordion__content h1:first-child,
+.jazz-accordion__content h2:first-child,
+.jazz-accordion__content h3:first-child,
+.jazz-accordion__content h4:first-child,
+.jazz-accordion__content h5:first-child,
+.jazz-accordion__content h6:first-child,
+.jazz-accordion__content ul:first-child,
+.jazz-accordion__content ol:first-child,
+.jazz-accordion__content blockquote:first-child {
+    margin-block-start: 0;
+}
+.jazz-accordion__content p:last-child ,
+.jazz-accordion__content h1:last-child,
+.jazz-accordion__content h2:last-child,
+.jazz-accordion__content h3:last-child,
+.jazz-accordion__content h4:last-child,
+.jazz-accordion__content h5:last-child,
+.jazz-accordion__content h6:last-child,
+.jazz-accordion__content ul:last-child,
+.jazz-accordion__content ol:last-child,
+.jazz-accordion__content blockquote:last-child {
+  margin-block-end: 0;
+}
 .jazz-accordion__content--expanded {
   margin-top: px-to-rem(20);
   margin-bottom: px-to-rem(16);

--- a/stories/Accordion.stories.mdx
+++ b/stories/Accordion.stories.mdx
@@ -240,6 +240,7 @@ export const TestCollapsedHtmlStyles = (args) => html`
                   Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem.
                 </li>
             </ul>
+            <p>Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula.</p>
           </div>
           <h2>
             <button class="jazz-accordion__button" aria-controls="content6">This contains an ordered list</button>
@@ -257,6 +258,7 @@ export const TestCollapsedHtmlStyles = (args) => html`
                   Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem.
                 </li>
             </ol>
+            <p>Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula.</p>
           </div>
           <h2>
             <button class="jazz-accordion__button" aria-controls="content7">This contains a table</button>

--- a/stories/Accordion.stories.mdx
+++ b/stories/Accordion.stories.mdx
@@ -147,6 +147,380 @@ export const BorderedTemplate = (args) => html`
       </script>
   `;
 
+<!-- This Storybook component tests out the default browser behaviors for the HTML tags being tested in the Accordion -->
+export const TestCollapsedHtmlStyles = (args) => html`
+      <div class="jazz-accordion" role="region">
+          <h2>
+            <button class="jazz-accordion__button" aria-controls="content1">This contains a single paragraph tag</button>
+          </h2>
+          <div class="jazz-accordion__content" id="content1">
+            <p>
+              Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Praesent sapien massa, convallis a
+              pellentesque nec, egestas non nisi.
+            </p>
+          </div>
+          <h2>
+            <button id="acrd-btn-2" class="jazz-accordion__button" aria-expanded="true" aria-controls="content2">This contains multiple paragraph tags</button>
+          </h2>
+          <div class="jazz-accordion__content jazz-accordion__content--expanded" id="content2">
+            <p>
+              Quisque velit nisi, pretium ut lacinia in, elementum id enim. Curabitur arcu erat, accumsan id imperdiet
+              et, porttitor at sem. Curabitur non nulla sit amet nisl tempus convallis quis ac lectus.
+              Cras ultricies ligula sed magna dictum porta.
+            </p>
+            <p>
+              Quisque velit nisi, pretium ut lacinia in, elementum id enim. Curabitur arcu erat, accumsan id imperdiet
+              et, porttitor at sem. Curabitur non nulla sit amet nisl tempus convallis quis ac lectus.
+              Cras ultricies ligula sed magna dictum porta.
+            </p>
+            <p>
+              Quisque velit nisi, pretium ut lacinia in, elementum id enim. Curabitur arcu erat, accumsan id imperdiet
+              et, porttitor at sem. Curabitur non nulla sit amet nisl tempus convallis quis ac lectus.
+              Cras ultricies ligula sed magna dictum porta.
+            </p>
+          </div>
+          <h2>
+            <button id="acrd-btn-2" class="jazz-accordion__button" aria-controls="content3">This contains a single heading tag</button>
+          </h2>
+          <div class="jazz-accordion__content" id="content3">
+            <h1>
+              Quisque velit nisi, pretium ut lacinia in, elementum id enim. Curabitur arcu erat, accumsan id imperdiet
+              et, porttitor at sem. Curabitur non nulla sit amet nisl tempus convallis quis ac lectus.
+              Cras ultricies ligula sed magna dictum porta.
+            </h1>
+          </div>
+          <h2>
+            <button id="acrd-btn-2" class="jazz-accordion__button" aria-controls="content4">This contains multiple heading tags</button>
+          </h2>
+          <div class="jazz-accordion__content" id="content4">
+            <h1>
+              Quisque velit nisi, pretium ut lacinia in, elementum id enim. Curabitur arcu erat, accumsan id imperdiet
+              et, porttitor at sem. Curabitur non nulla sit amet nisl tempus convallis quis ac lectus.
+              Cras ultricies ligula sed magna dictum porta.
+            </h1>
+            <h2>
+              Quisque velit nisi, pretium ut lacinia in, elementum id enim. Curabitur arcu erat, accumsan id imperdiet
+              et, porttitor at sem. Curabitur non nulla sit amet nisl tempus convallis quis ac lectus.
+              Cras ultricies ligula sed magna dictum porta.
+            </h2>
+            <h3>
+              Quisque velit nisi, pretium ut lacinia in, elementum id enim. Curabitur arcu erat, accumsan id imperdiet
+              et, porttitor at sem. Curabitur non nulla sit amet nisl tempus convallis quis ac lectus.
+              Cras ultricies ligula sed magna dictum porta.
+            </h3>
+            <h4>
+              Quisque velit nisi, pretium ut lacinia in, elementum id enim. Curabitur arcu erat, accumsan id imperdiet
+              et, porttitor at sem. Curabitur non nulla sit amet nisl tempus convallis quis ac lectus.
+              Cras ultricies ligula sed magna dictum porta.
+            </h4>
+            <h5>
+              Quisque velit nisi, pretium ut lacinia in, elementum id enim. Curabitur arcu erat, accumsan id imperdiet
+              et, porttitor at sem. Curabitur non nulla sit amet nisl tempus convallis quis ac lectus.
+              Cras ultricies ligula sed magna dictum porta.
+            </h5>
+            <h6>
+              Quisque velit nisi, pretium ut lacinia in, elementum id enim. Curabitur arcu erat, accumsan id imperdiet
+              et, porttitor at sem. Curabitur non nulla sit amet nisl tempus convallis quis ac lectus.
+              Cras ultricies ligula sed magna dictum porta.
+            </h6>
+          </div>
+          <h2>
+            <button class="jazz-accordion__button" aria-controls="content5">This contains an unordered list</button>
+          </h2>
+          <div class="jazz-accordion__content" id="content5">
+            <ul>
+                <li>
+                  Nulla porttitor accumsan tincidunt. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices
+                  posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula.
+                  Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem.
+                </li>
+                <li>
+                  Nulla porttitor accumsan tincidunt. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices
+                  posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula.
+                  Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem.
+                </li>
+            </ul>
+          </div>
+          <h2>
+            <button class="jazz-accordion__button" aria-controls="content6">This contains an ordered list</button>
+          </h2>
+          <div class="jazz-accordion__content" id="content6">
+            <ol>
+                <li>
+                  Nulla porttitor accumsan tincidunt. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices
+                  posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula.
+                  Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem.
+                </li>
+                <li>
+                  Nulla porttitor accumsan tincidunt. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices
+                  posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula.
+                  Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem.
+                </li>
+            </ol>
+          </div>
+          <h2>
+            <button class="jazz-accordion__button" aria-controls="content7">This contains a table</button>
+          </h2>
+          <div class="jazz-accordion__content" id="content7">
+            <table>
+              <tr>
+                <th>Company</th>
+                <th>Contact</th>
+                <th>Country</th>
+                <th>Founded</th>
+                <th>Visited</th>
+              </tr>
+              <tr>
+                <td><a href="#">Alfreds Futterkiste</a></td>
+                <td>Maria Anders</td>
+                <td>Germany</td>
+                <td>1994</td>
+                <td>
+                    <button>Yes</button>
+                    <button>No</button>
+                </td>
+              </tr>
+              <tr>
+                <td><a href="#">Centro comercial Moctezuma</a></td>
+                <td>Francisco Chang</td>
+                <td>Mexico</td>
+                <td>2006</td>
+                <td>
+                    <button>Yes</button>
+                    <button>No</button>
+                </td>
+              </tr>
+              <tr>
+                <td><a href="#">Electrolux</a></td>
+                <td>Paul Adams</td>
+                <td>US</td>
+                <td>2016</td>
+                <td>
+                    <button>Yes</button>
+                    <button>No</button>
+                </td>
+              </tr>
+              <tr>
+                <td><a href="#">XILINX</a></td>
+                <td>Candice Krueger</td>
+                <td>US</td>
+                <td>2009</td>
+                <td>
+                    <button>Yes</button>
+                    <button>No</button>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <h2>
+            <button class="jazz-accordion__button" aria-controls="content8">This contains multiple tables</button>
+          </h2>
+          <div class="jazz-accordion__content" id="content8">
+            <table>
+              <tr>
+                <th>Company</th>
+                <th>Contact</th>
+                <th>Country</th>
+                <th>Founded</th>
+              </tr>
+              <tr>
+                <td><a href="#">Alfreds Futterkiste</a></td>
+                <td>Maria Anders</td>
+                <td>Germany</td>
+                <td>1994</td>
+                <td>
+                    <button>Yes</button>
+                    <button>No</button>
+                </td>
+              </tr>
+              <tr>
+                <td><a href="#">Centro comercial Moctezuma</a></td>
+                <td>Francisco Chang</td>
+                <td>Mexico</td>
+                <td>2006</td>
+                <td>
+                    <button>Yes</button>
+                    <button>No</button>
+                </td>
+              </tr>
+              <tr>
+                <td><a href="#">Electrolux</a></td>
+                <td>Paul Adams</td>
+                <td>US</td>
+                <td>2016</td>
+                <td>
+                    <button>Yes</button>
+                    <button>No</button>
+                </td>
+              </tr>
+              <tr>
+                <td><a href="#">XILINX</a></td>
+                <td>Candice Krueger</td>
+                <td>US</td>
+                <td>2009</td>
+                <td>
+                    <button>Yes</button>
+                    <button>No</button>
+                </td>
+              </tr>
+            </table>
+            <table>
+              <tr>
+                <th>Company</th>
+                <th>Contact</th>
+                <th>Country</th>
+                <th>Founded</th>
+              </tr>
+              <tr>
+                <td><a href="#">Alfreds Futterkiste</a></td>
+                <td>Maria Anders</td>
+                <td>Germany</td>
+                <td>1994</td>
+                <td>
+                    <button>Yes</button>
+                    <button>No</button>
+                </td>
+              </tr>
+              <tr>
+                <td><a href="#">Centro comercial Moctezuma</a></td>
+                <td>Francisco Chang</td>
+                <td>Mexico</td>
+                <td>2006</td>
+                <td>
+                    <button>Yes</button>
+                    <button>No</button>
+                </td>
+              </tr>
+              <tr>
+                <td><a href="#">Electrolux</a></td>
+                <td>Paul Adams</td>
+                <td>US</td>
+                <td>2016</td>
+                <td>
+                    <button>Yes</button>
+                    <button>No</button>
+                </td>
+              </tr>
+              <tr>
+                <td><a href="#">XILINX</a></td>
+                <td>Candice Krueger</td>
+                <td>US</td>
+                <td>2009</td>
+                <td>
+                    <button>Yes</button>
+                    <button>No</button>
+                </td>
+              </tr>
+            </table>
+            <table>
+              <tr>
+                <th>Company</th>
+                <th>Contact</th>
+                <th>Country</th>
+                <th>Founded</th>
+              </tr>
+              <tr>
+                <td><a href="#">Alfreds Futterkiste</a></td>
+                <td>Maria Anders</td>
+                <td>Germany</td>
+                <td>1994</td>
+                <td>
+                    <button>Yes</button>
+                    <button>No</button>
+                </td>
+              </tr>
+              <tr>
+                <td><a href="#">Centro comercial Moctezuma</a></td>
+                <td>Francisco Chang</td>
+                <td>Mexico</td>
+                <td>2006</td>
+                <td>
+                    <button>Yes</button>
+                    <button>No</button>
+                </td>
+              </tr>
+              <tr>
+                <td><a href="#">Electrolux</a></td>
+                <td>Paul Adams</td>
+                <td>US</td>
+                <td>2016</td>
+                <td>
+                    <button>Yes</button>
+                    <button>No</button>
+                </td>
+              </tr>
+              <tr>
+                <td><a href="#">XILINX</a></td>
+                <td>Candice Krueger</td>
+                <td>US</td>
+                <td>2009</td>
+                <td>
+                    <button>Yes</button>
+                    <button>No</button>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <h2>
+            <button class="jazz-accordion__button" aria-controls="content9">This contains a quote</button>
+          </h2>
+          <div class="jazz-accordion__content" id="content9">
+            <q>
+              Nulla porttitor accumsan tincidunt. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices
+              posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula.
+              Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem.
+            </q>
+          </div>
+          <h2>
+            <button class="jazz-accordion__button" aria-controls="content10">This contains a blockquote</button>
+          </h2>
+          <div class="jazz-accordion__content" id="content10">
+            <blockquote cite="#">
+              Nulla porttitor accumsan tincidunt. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices
+              posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula.
+              Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem.
+            </blockquote>
+          </div>
+          <h2>
+            <button class="jazz-accordion__button" aria-controls="content11">This contains a form with inputs</button>
+          </h2>
+          <div class="jazz-accordion__content" id="content11">
+              <form>
+                 <label for="fname">First name:</label><br>
+                 <input type="text" id="fname" name="fname"><br>
+                 <label for="lname">Last name:</label><br>
+                 <input type="text" id="lname" name="lname">
+              </form>
+          </div>
+          <h2>
+            <button class="jazz-accordion__button" aria-controls="content12">This contains a form with a textarea</button>
+          </h2>
+          <div class="jazz-accordion__content" id="content12">
+              <form>
+                 <label for="fname">Feedback:</label><br>
+                 <textarea id="textareaname" name="textareaname">
+Nulla porttitor accumsan tincidunt. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices
+posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula.
+Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem.
+                 </textarea>
+              </form>
+          </div>
+          <h2>
+            <button class="jazz-accordion__button" aria-controls="content13">This contains a header tag, containing a heading and multiple paragraph tags</button>
+          </h2>
+          <div class="jazz-accordion__content" id="content13">
+            <header>
+                <h3>Nulla porttitor</h3>
+                <p>accumsan tincidunt vestibulum ante ipsum primis.</p>
+                <p>ante ipsum primis in faucibus orci luctus et ultrices</p>
+            </header>
+          </div>
+      </div>
+      <script id="initscript">
+        PrincetonDesignSystem.enableDesignSystem();
+      </script>
+  `;
+
 # Accordion
 
 An "Accordion" allows page content to be collapsed under a header.
@@ -169,5 +543,12 @@ An "Accordion" allows page content to be collapsed under a header.
     <Story name="Bordered" args={{
     }}>
       {BorderedTemplate.bind({})}
+    </Story>
+</Canvas>
+
+<Canvas>
+    <Story name="Test Collapsed HTML Styles" args={{
+    }}>
+      {TestCollapsedHtmlStyles.bind({})}
     </Story>
 </Canvas>


### PR DESCRIPTION
- Add CSS styles to remove extra accordion content margins when collapsed. The added styles will override the default browser behavior to remove the extra margins for `first-child` and `last-child`
- How to test these components: run storybook, and under "Accordions" > "Test Collapsed Html Styles"